### PR TITLE
Reporting via annotation for Testng and JUnit5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 
 .idea
 *.iml
+
+/target

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Please also ensure you set the following system variables:
 </systemPropertyVariables>
 ```
 
-### JUnit5 Listener
+### JUnit5 Extension
 Add the following to your base/test class:
 ```
-@ExtendWith(AnglesJUnit5TestListener.class)
+@ExtendWith(AnglesJUnit5TestExtension.class)
 ```
 Please also ensure you set the following system variables:
 ```
@@ -46,3 +46,21 @@ Please also ensure you set the following system variables:
     <angles.environment>SampleEnvironmentName</angles.environment>
 </systemPropertyVariables>
 ```
+
+
+### Log4j2 Appender
+Add the appender to your log4j2 configuration file:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO" packages="com.github.angleshq.angles.listeners.log4j2.AnglesLog4j2LogAppender">
+    <Appenders>
+        <AnglesLog4j2LogAppender name="AnglesLog4j2LogAppender"/>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="AnglesLog4j2LogAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>
+```
+Please bear in mind that this appender standalone will not be able to push logs to your Angles Dashboard and requires this to be coupled with a test execution framework like JUnit5 or Testng. i.e. This plugin will not create new runs/builds.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Simply add the following dependency to your POM:
   <version>1.0.0-BETA4</version>
 </dependency>
 ```
+
+
+
+### Testng Listener
+Add the following to your base/test class:
+```
+@Listeners({AnglesTestngTestListener.class})
+```

--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ Add the following to your base/test class:
 ```
 @Listeners({AnglesTestngTestListener.class})
 ```
+Please also ensure you set the following system variables:
+```
+<systemPropertyVariables>
+    <angles.url>http://127.0.0.1:3000</angles.url>
+    <angles.runName>SampleRunName</angles.runName>
+    <angles.team>SampleTeamName</angles.team>
+    <angles.component>SampleComponent</angles.component>
+    <angles.environment>SampleEnvironmentName</angles.environment>
+</systemPropertyVariables>
+```
+
+### JUnit5 Listener
+Add the following to your base/test class:
+```
+@ExtendWith(AnglesJUnit5TestListener.class)
+```
+Please also ensure you set the following system variables:
+```
+<systemPropertyVariables>
+    <angles.url>http://127.0.0.1:3000</angles.url>
+    <angles.runName>SampleRunName</angles.runName>
+    <angles.team>SampleTeamName</angles.team>
+    <angles.component>SampleComponent</angles.component>
+    <angles.environment>SampleEnvironmentName</angles.environment>
+</systemPropertyVariables>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -131,15 +131,19 @@
             <version>1.18.10</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>7.4.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.0</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -145,5 +145,10 @@
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,16 @@
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/github/angleshq/angles/exceptions/AnglesPropertyNotGivenException.java
+++ b/src/main/java/com/github/angleshq/angles/exceptions/AnglesPropertyNotGivenException.java
@@ -1,0 +1,7 @@
+package com.github.angleshq.angles.exceptions;
+
+public class AnglesPropertyNotGivenException extends Exception {
+    public AnglesPropertyNotGivenException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/com/github/angleshq/angles/listeners/AbstractAnglesListener.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/AbstractAnglesListener.java
@@ -49,7 +49,7 @@ public class AbstractAnglesListener {
         anglesReporter.saveTest();
     }
 
-    protected String getAnglesPropertyFromSystem(String property) throws AnglesPropertyNotGivenException {
+    public static String getAnglesPropertyFromSystem(String property) throws AnglesPropertyNotGivenException {
         String propertyValue = System.getProperty(property);
         if(isBlank(propertyValue)) {
             throw new AnglesPropertyNotGivenException("Detected that property [" + property + "] was not given. Please add this mandatory property as a system property");

--- a/src/main/java/com/github/angleshq/angles/listeners/AbstractAnglesListener.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/AbstractAnglesListener.java
@@ -1,0 +1,60 @@
+package com.github.angleshq.angles.listeners;
+
+import com.github.angleshq.angles.AnglesReporter;
+import com.github.angleshq.angles.exceptions.AnglesPropertyNotGivenException;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class AbstractAnglesListener {
+
+    protected AnglesReporter anglesReporter;
+    protected String runName;
+    protected String team;
+    protected String component;
+    protected String environment;
+
+    protected void initialiseAnglesTestParameters() throws AnglesPropertyNotGivenException {
+        anglesReporter = AnglesReporter.getInstance(getAnglesPropertyFromSystem("angles.url") + "/rest/api/v1.0/");
+        runName = getAnglesPropertyFromSystem("angles.runName");
+        team = getAnglesPropertyFromSystem("angles.team");
+        component = getAnglesPropertyFromSystem("angles.component");
+        environment = getAnglesPropertyFromSystem("angles.environment");
+    }
+
+    protected void startAnglesBuild() {
+        anglesReporter.startBuild(runName, environment, team, component);
+    }
+
+    protected void startAnglesTest(String SuiteName, String testName) {
+        anglesReporter.startTest(SuiteName, testName);
+    }
+
+    protected void anglesTestSuccess() {
+        anglesReporter.pass("Test Passed", "true", "true", EMPTY);
+        anglesReporter.saveTest();
+    }
+
+    protected void anglesTestFailure(String message) {
+        anglesReporter.fail("Test Failed", "true", "false", message);
+        anglesReporter.saveTest();
+    }
+
+    protected void anglesTestFailure() {
+        anglesTestFailure(EMPTY);
+    }
+
+    protected void anglesTestSkipped() {
+        anglesReporter.info("Test has been skipped");
+        anglesReporter.saveTest();
+    }
+
+    protected String getAnglesPropertyFromSystem(String property) throws AnglesPropertyNotGivenException {
+        String propertyValue = System.getProperty(property);
+        if(isBlank(propertyValue)) {
+            throw new AnglesPropertyNotGivenException("Detected that property [" + property + "] was not given. Please add this mandatory property as a system property");
+        }
+        return propertyValue;
+    }
+
+}

--- a/src/main/java/com/github/angleshq/angles/listeners/junit/AnglesJUnit5TestExtension.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/junit/AnglesJUnit5TestExtension.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class AnglesJUnit5TestListener extends AbstractAnglesListener implements BeforeAllCallback, BeforeEachCallback,
+public class AnglesJUnit5TestExtension extends AbstractAnglesListener implements BeforeAllCallback, BeforeEachCallback,
          AfterEachCallback, AfterAllCallback {
 
-    public AnglesJUnit5TestListener() throws AnglesPropertyNotGivenException {
+    public AnglesJUnit5TestExtension() throws AnglesPropertyNotGivenException {
         initialiseAnglesTestParameters();
     }
 
@@ -22,6 +22,7 @@ public class AnglesJUnit5TestListener extends AbstractAnglesListener implements 
 
     @Override
     public void afterAll(ExtensionContext extensionContext) throws Exception {
+
     }
 
     @Override

--- a/src/main/java/com/github/angleshq/angles/listeners/junit/AnglesJUnit5TestListener.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/junit/AnglesJUnit5TestListener.java
@@ -1,0 +1,42 @@
+package com.github.angleshq.angles.listeners.junit;
+
+import com.github.angleshq.angles.exceptions.AnglesPropertyNotGivenException;
+import com.github.angleshq.angles.listeners.AbstractAnglesListener;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class AnglesJUnit5TestListener extends AbstractAnglesListener implements BeforeAllCallback, BeforeEachCallback,
+         AfterEachCallback, AfterAllCallback {
+
+    public AnglesJUnit5TestListener() throws AnglesPropertyNotGivenException {
+        initialiseAnglesTestParameters();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        startAnglesBuild();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) throws Exception {
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        if(extensionContext.getExecutionException().isPresent()) {
+            anglesTestFailure("Test failed due to: [" +
+                    extensionContext.getExecutionException().get().getClass().getSimpleName() + "]");
+        } else {
+            anglesTestSuccess();
+        }
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        startAnglesTest(extensionContext.getTestMethod().get().getDeclaringClass().getSimpleName(),
+                extensionContext.getTestMethod().get().getName());
+    }
+}

--- a/src/main/java/com/github/angleshq/angles/listeners/log4j2/AnglesLog4j2LogAppender.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/log4j2/AnglesLog4j2LogAppender.java
@@ -1,0 +1,62 @@
+package com.github.angleshq.angles.listeners.log4j2;
+
+import com.github.angleshq.angles.AnglesReporter;
+import com.github.angleshq.angles.exceptions.AnglesPropertyNotGivenException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+import java.io.Serializable;
+
+import static com.github.angleshq.angles.listeners.AbstractAnglesListener.getAnglesPropertyFromSystem;
+
+@Plugin(name = "AnglesLog4j2LogAppender", category = "Core", elementType = Appender.ELEMENT_TYPE)
+public class AnglesLog4j2LogAppender extends AbstractAppender {
+
+    protected AnglesReporter anglesReporter;
+    protected String runName;
+    protected String team;
+    protected String component;
+    protected String environment;
+
+    protected AnglesLog4j2LogAppender(String name, Filter filter, Layout<? extends Serializable> layout,
+                                      boolean ignoreExceptions, Property[] properties)
+                                        throws AnglesPropertyNotGivenException {
+        super(name, filter, layout, ignoreExceptions, properties);
+        anglesReporter = AnglesReporter.getInstance(getAnglesPropertyFromSystem("angles.url") + "/rest/api/v1.0/");
+        runName = getAnglesPropertyFromSystem("angles.runName");
+        team = getAnglesPropertyFromSystem("angles.team");
+        component = getAnglesPropertyFromSystem("angles.component");
+        environment = getAnglesPropertyFromSystem("angles.environment");
+    }
+
+    @PluginFactory
+    public static AnglesLog4j2LogAppender createAppender(
+            @PluginAttribute("name") String name,
+            @PluginElement("Filter") Filter filter) throws AnglesPropertyNotGivenException {
+        return new AnglesLog4j2LogAppender(name, filter, null, true, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        Level logLevel = event.getLevel();
+        switch(logLevel.toString()) {
+            case "DEBUG":
+                anglesReporter.debug(event.getMessage().getFormattedMessage());
+                break;
+            case "ERROR":
+                anglesReporter.error(event.getMessage().getFormattedMessage());
+                break;
+            default:
+                anglesReporter.info(event.getMessage().getFormattedMessage());
+        }
+    }
+}

--- a/src/main/java/com/github/angleshq/angles/listeners/testng/AnglesTestngTestListener.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/testng/AnglesTestngTestListener.java
@@ -1,0 +1,64 @@
+package com.github.angleshq.angles.listeners.testng;
+
+import com.github.angleshq.angles.AnglesReporter;
+import com.github.angleshq.angles.exceptions.AnglesPropertyNotGivenException;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class AnglesTestngTestListener implements ITestListener {
+
+    private AnglesReporter anglesReporter;
+    private String runName;
+    private String team;
+    private String component;
+    private String environment;
+
+    public AnglesTestngTestListener() throws AnglesPropertyNotGivenException {
+        anglesReporter = AnglesReporter.getInstance(getAnglesPropertyFromSystem("angles.url") + "/rest/api/v1.0/");
+        runName = getAnglesPropertyFromSystem("angles.runName");
+        team = getAnglesPropertyFromSystem("angles.team");
+        component = getAnglesPropertyFromSystem("angles.component");
+        environment = getAnglesPropertyFromSystem("angles.environment");
+    }
+
+    public void onStart(ITestContext context) {
+        anglesReporter.startBuild(runName, environment, team, component);
+    }
+
+    public void onFinish(ITestContext context) {
+
+    }
+
+    public void onTestStart(ITestResult result) {
+        anglesReporter.startTest(result.getMethod().getRealClass().getSimpleName(), result.getMethod().getMethodName());
+    }
+
+    public void onTestSuccess(ITestResult result) {
+        anglesReporter.pass("Test Passed", "true", "true", EMPTY);
+        anglesReporter.saveTest();
+    }
+
+    public void onTestFailure(ITestResult result) {
+        anglesReporter.fail("Test Failed", "true", "false", EMPTY);
+        anglesReporter.saveTest();
+    }
+
+    public void onTestSkipped(ITestResult result) {
+        anglesReporter.info("Test has been skipped");
+        anglesReporter.saveTest();
+    }
+
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
+
+    private String getAnglesPropertyFromSystem(String property) throws AnglesPropertyNotGivenException {
+        String propertyValue = System.getProperty(property);
+        if(isBlank(propertyValue)) {
+            throw new AnglesPropertyNotGivenException("Detected that property [" + property + "] was not given. Please add this mandatory property as a system property");
+        }
+        return propertyValue;
+    }
+}

--- a/src/main/java/com/github/angleshq/angles/listeners/testng/AnglesTestngTestListener.java
+++ b/src/main/java/com/github/angleshq/angles/listeners/testng/AnglesTestngTestListener.java
@@ -1,32 +1,19 @@
 package com.github.angleshq.angles.listeners.testng;
 
-import com.github.angleshq.angles.AnglesReporter;
 import com.github.angleshq.angles.exceptions.AnglesPropertyNotGivenException;
+import com.github.angleshq.angles.listeners.AbstractAnglesListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
-public class AnglesTestngTestListener implements ITestListener {
-
-    private AnglesReporter anglesReporter;
-    private String runName;
-    private String team;
-    private String component;
-    private String environment;
+public class AnglesTestngTestListener extends AbstractAnglesListener implements ITestListener {
 
     public AnglesTestngTestListener() throws AnglesPropertyNotGivenException {
-        anglesReporter = AnglesReporter.getInstance(getAnglesPropertyFromSystem("angles.url") + "/rest/api/v1.0/");
-        runName = getAnglesPropertyFromSystem("angles.runName");
-        team = getAnglesPropertyFromSystem("angles.team");
-        component = getAnglesPropertyFromSystem("angles.component");
-        environment = getAnglesPropertyFromSystem("angles.environment");
+        initialiseAnglesTestParameters();
     }
 
     public void onStart(ITestContext context) {
-        anglesReporter.startBuild(runName, environment, team, component);
+        startAnglesBuild();
     }
 
     public void onFinish(ITestContext context) {
@@ -34,31 +21,20 @@ public class AnglesTestngTestListener implements ITestListener {
     }
 
     public void onTestStart(ITestResult result) {
-        anglesReporter.startTest(result.getMethod().getRealClass().getSimpleName(), result.getMethod().getMethodName());
+        startAnglesTest(result.getMethod().getRealClass().getSimpleName(), result.getMethod().getMethodName());
     }
 
     public void onTestSuccess(ITestResult result) {
-        anglesReporter.pass("Test Passed", "true", "true", EMPTY);
-        anglesReporter.saveTest();
+        anglesTestSuccess();
     }
 
     public void onTestFailure(ITestResult result) {
-        anglesReporter.fail("Test Failed", "true", "false", EMPTY);
-        anglesReporter.saveTest();
+        anglesTestFailure();
     }
 
     public void onTestSkipped(ITestResult result) {
-        anglesReporter.info("Test has been skipped");
-        anglesReporter.saveTest();
+        anglesTestSkipped();
     }
 
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
-
-    private String getAnglesPropertyFromSystem(String property) throws AnglesPropertyNotGivenException {
-        String propertyValue = System.getProperty(property);
-        if(isBlank(propertyValue)) {
-            throw new AnglesPropertyNotGivenException("Detected that property [" + property + "] was not given. Please add this mandatory property as a system property");
-        }
-        return propertyValue;
-    }
 }


### PR DESCRIPTION
Very basic implementation to allow Testng and JUnit5 tests to be pushed into Angles with their final test status shown

Example runs given below for each testing framework

![Screenshot 2021-03-26 at 10 38 14](https://user-images.githubusercontent.com/3577952/112620155-0cd02f80-8e20-11eb-9f27-cdf8fad6cd88.png)


![Screenshot 2021-03-26 at 10 37 55](https://user-images.githubusercontent.com/3577952/112620186-15286a80-8e20-11eb-9c06-4d88227af12a.png)
