### PR TITLE
Adding platform details and tags in create screenshot call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.angleshq</groupId>
     <artifactId>angles-java-client</artifactId>
-    <version>1.0.0-BETA6</version>
+    <version>1.0.1</version>
 
     <name>Angles Java client</name>
     <description>This is the java client for the Angles test results dashboard and contains all the necessary methods to store your test results in the Angles dashboard</description>

--- a/src/main/java/com/github/angleshq/angles/AnglesReporter.java
+++ b/src/main/java/com/github/angleshq/angles/AnglesReporter.java
@@ -58,6 +58,7 @@ public class AnglesReporter {
         createBuild.setEnvironment(environmentName);
         createBuild.setTeam(teamName);
         createBuild.setComponent(componentName);
+        createBuild.setStart(new Date());
         try {
             currentBuild.set(buildRequests.create(createBuild));
         } catch (IOException | AnglesServerException exception) {
@@ -197,10 +198,10 @@ public class AnglesReporter {
         createScreenshot.setTimestamp(new Date());
         createScreenshot.setView(details.getView());
         createScreenshot.setFilePath(details.getPath());
+        createScreenshot.setPlatform(details.getPlatform());
+        createScreenshot.setTags(details.getTags());
         try {
             Screenshot response = screenshotRequests.create(createScreenshot);
-            // we need to store the platform details or tags
-            storeScreenshotDetails(response.getId(), details);
             return response;
         } catch (IOException | AnglesServerException exception) {
             throw new Error("Unable store screenshot due to [" + exception.getMessage() + "]");
@@ -221,18 +222,5 @@ public class AnglesReporter {
             }
         }
         return null;
-    }
-
-    private void storeScreenshotDetails(String screenshotId, ScreenshotDetails details) {
-        if (details.getPlatform() != null || details.getTags() != null) {
-            UpdateScreenshot updateScreenshot = new UpdateScreenshot();
-            if (details.getPlatform() != null) updateScreenshot.setPlatform(details.getPlatform());
-            if (details.getTags() != null) updateScreenshot.setTags(details.getTags());
-            try {
-                screenshotRequests.update(screenshotId, updateScreenshot);
-            } catch (IOException | AnglesServerException exception) {
-                throw new Error("Unable update screenshot due to [" + exception.getMessage() + "]");
-            }
-        }
     }
 }

--- a/src/main/java/com/github/angleshq/angles/api/models/build/CreateBuild.java
+++ b/src/main/java/com/github/angleshq/angles/api/models/build/CreateBuild.java
@@ -5,11 +5,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.Date;
 
 @NoArgsConstructor @Getter @Setter
 public class CreateBuild implements Serializable {
     private String team;
     private String environment;
     private String name;
+    private Date start;
     private String component;
 }

--- a/src/main/java/com/github/angleshq/angles/api/models/screenshot/CreateScreenshot.java
+++ b/src/main/java/com/github/angleshq/angles/api/models/screenshot/CreateScreenshot.java
@@ -1,18 +1,22 @@
 package com.github.angleshq.angles.api.models.screenshot;
 
+import com.github.angleshq.angles.api.models.Platform;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.List;
 
 @Getter @Setter @NoArgsConstructor
 public class CreateScreenshot implements Serializable {
 
     private String buildId;
-    private String view;
     private Date timestamp;
+    private String view;
     private String filePath;
+    private Platform platform;
+    private List<String> tags;
 
 }


### PR DESCRIPTION
- fixed start date issue for builds
- updated create screenshot to provide platform + tags in one request (rather than having to make a separate request).