### PR TITLE
Adding delayed reporter which can send the whole build as one request

### DIFF
--- a/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesDelayedReporter.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesDelayedReporter.java
@@ -1,0 +1,80 @@
+package com.github.angleshq.angles;
+
+import com.github.angleshq.angles.api.exceptions.AnglesServerException;
+import com.github.angleshq.angles.api.models.build.Artifact;
+import com.github.angleshq.angles.api.models.build.Build;
+import com.github.angleshq.angles.api.models.build.CreateBuild;
+import com.github.angleshq.angles.api.models.screenshot.Screenshot;
+import com.github.angleshq.angles.api.models.screenshot.ScreenshotDetails;
+import org.apache.commons.lang3.SerializationUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class AnglesDelayedReporter extends AnglesReporter implements AnglesReporterInterface {
+
+    protected InheritableThreadLocal<CreateBuild> currentCreateBuildRequest = new InheritableThreadLocal<>();
+
+    public AnglesDelayedReporter(String baseUrl) {
+        super(baseUrl);
+    }
+
+    public void startBuild(String name, String environmentName, String teamName, String componentName, String phase) {
+        if (currentCreateBuildRequest.get() != null) {
+            return;
+        }
+        CreateBuild createBuild = createBuild(name, environmentName, teamName, componentName, phase);
+        currentCreateBuildRequest.set(createBuild);
+    }
+
+    /**
+     * This method will save the store build
+     */
+    @Override
+    public void saveBuild() {
+        try {
+            Build build = buildRequests.create(this.currentCreateBuildRequest.get());
+            System.out.println(build.getId() + ": " + build.toString());
+        }  catch (IOException | AnglesServerException exception) {
+            throw new Error("Unable to save build due to [" + exception.getMessage() + "]");
+        }
+    }
+
+    @Override
+    public void storeArtifacts(Artifact[] artifacts) {
+        this.currentCreateBuildRequest.get().setArtifacts(Arrays.asList(artifacts));
+    }
+
+    @Override
+    public void startSuite(String suiteName) {
+        super.startSuite(suiteName);
+        this.currentCreateBuildRequest.get().addSuite(this.currentSuite.get());
+    }
+
+    @Override
+    public void startTest(String suiteName, String testName, String feature, List<String> tags) {
+        super.startTest(suiteName, testName, feature, tags);
+    }
+
+    /**
+     * Delayed reporter does not support screenshots.
+     * @param details
+     * @return
+     */
+    public Screenshot storeScreenshot(ScreenshotDetails details) {
+        Screenshot screenshot = new Screenshot();
+        screenshot.setId(null);
+        return screenshot;
+    }
+
+    @Override
+    public void saveTest() {
+        // do nothing.
+        if (currentExecution.get() != null) {
+            this.currentSuite.get().getExecutions().add(SerializationUtils.clone(this.currentExecution.get()));
+            currentExecution.set(null);
+        }
+    }
+
+}

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesReporterEmpty.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesReporterEmpty.java
@@ -22,7 +22,17 @@ public class AnglesReporterEmpty implements AnglesReporterInterface {
         // do nothing
     }
 
+    @Override
+    public void saveBuild() {
+        // do nothing
+    }
+
     public void storeArtifacts(Artifact[] artifacts) {
+        // do nothing
+    }
+
+    @Override
+    public void startSuite(String suiteName) {
         // do nothing
     }
 

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesReporterInterface.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/AnglesReporterInterface.java
@@ -14,7 +14,11 @@ public interface AnglesReporterInterface {
 
     void startBuild(String name, String environmentName, String teamName, String componentName, String phaseName);
 
+    void saveBuild();
+
     void storeArtifacts(Artifact[] artifacts);
+
+    void startSuite(String suiteName);
 
     void startTest(String suiteName, String testName);
 

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/Platform.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/Platform.java
@@ -4,8 +4,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Setter @Getter @NoArgsConstructor
-public class Platform {
+public class Platform implements Serializable {
 
     private String platformName;
     private String platformVersion;

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/build/CreateBuild.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/build/CreateBuild.java
@@ -5,7 +5,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @NoArgsConstructor @Getter @Setter
 public class CreateBuild implements Serializable {
@@ -15,4 +17,14 @@ public class CreateBuild implements Serializable {
     private String phase;
     private Date start;
     private String component;
+    private List<Artifact> artifacts = new ArrayList<>();
+    private List<Suite> suites = new ArrayList<>();
+
+    public void addArtifact(Artifact artifact) {
+        this.artifacts.add(artifact);
+    }
+
+    public void addSuite(Suite suite) {
+        this.suites.add(suite);
+    }
 }

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/build/Suite.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/build/Suite.java
@@ -1,5 +1,6 @@
 package com.github.angleshq.angles.api.models.build;
 
+import com.github.angleshq.angles.api.models.execution.CreateExecution;
 import com.github.angleshq.angles.api.models.execution.Execution;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +12,11 @@ import java.util.List;
 @Getter @Setter @NoArgsConstructor
 public class Suite {
     private String name;
-    private List<Execution> executions = new ArrayList<>();
+    private CreateExecution setup;
+    private CreateExecution teardown;
+    private List<CreateExecution> executions = new ArrayList<>();
 
-    public void addExecution(Execution execution) {
+    public void addExecution(CreateExecution execution) {
         this.executions.add(execution);
     }
 }

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Action.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Action.java
@@ -3,11 +3,12 @@ package com.github.angleshq.angles.api.models.execution;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter @Setter
-public class Action {
+public class Action implements Serializable {
 
     private String name;
     private List<Step> steps = new ArrayList<Step>();

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/CreateExecution.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/CreateExecution.java
@@ -25,6 +25,13 @@ public class CreateExecution implements Serializable {
     private List<Action> actions = new CopyOnWriteArrayList<>();
     private List<Platform> platforms = new ArrayList<>();
 
+    public CreateExecution(String build, String title, String suite, Date start) {
+        this.build = build;
+        this.title = title;
+        this.suite = suite;
+        this.start = start;
+    }
+
     public void addTag(String tag) {
         this.tags.add(tag);
     }

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Execution.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Execution.java
@@ -21,7 +21,14 @@ public class Execution extends BaseModel {
     private List<Action> actions = new ArrayList<>();
     private List<Platform> platforms = new ArrayList<>();
 
-    public Execution(String build, String title, String suite, String feature,Date start) {
+    public Execution(String build, String title, String suite, Date start) {
+        this.build = build;
+        this.title = title;
+        this.suite = suite;
+        this.start = start;
+    }
+
+    public Execution(String build, String title, String suite, String feature, Date start) {
         this.build = build;
         this.title = title;
         this.suite = suite;

--- a/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Step.java
+++ b/angles-java-core/src/main/java/com/github/angleshq/angles/api/models/execution/Step.java
@@ -5,10 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.io.Serializable;
 import java.util.Date;
 
 @Setter @Getter @NoArgsConstructor
-public class Step {
+public class Step implements Serializable {
 
     private String name;
     private String expected;


### PR DESCRIPTION
This PR will change the way the create build api works and will allow you to pass in suites/executions as well which will be stored and added to the build (for reference and metrics).

This will be useful for  e.g. Unit Tests which don't want to send a request for every test.

https://github.com/AnglesHQ/angles/issues/36