### PR TITLE
updating lombok to latest (1.18.22 contains java 17 compatibility)

### DIFF
--- a/angles-java-core/pom.xml
+++ b/angles-java-core/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.30</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
@snevesbarros 

Lombok versions 1.18.21 and under are not compatible with Java version 17